### PR TITLE
Submission: duvo-eye-1, Holo-3.1-35B-A3B + LoRA (72.9% overall, self-reported)

### DIFF
--- a/model_factory.py
+++ b/model_factory.py
@@ -60,6 +60,14 @@ def build_model(args):
             model.load_model(model_name_or_path=model_name_or_path)
         else:
             model.load_model()
+    elif model_type == "duvo_eye_1":
+        from models.duvo_eye_1 import DuvoEye1Model
+
+        model = DuvoEye1Model()
+        if args.model_name_or_path:
+            model.load_model(model_name_or_path=model_name_or_path)
+        else:
+            model.load_model()
 
     elif model_type == "minicpmv":
         from models.minicpmv import MiniCPMVModel

--- a/models/duvo_eye_1.py
+++ b/models/duvo_eye_1.py
@@ -46,7 +46,7 @@ PROMPT_TEMPLATE = (
     "Localize an element on the GUI image according to the provided target "
     "and output a click position.\n"
     ' * You must output a valid JSON following the format: '
-    '{"x": int 0-1000, "y": int 0-1000}\n'
+    '{{"x": int 0-1000, "y": int 0-1000}}\n'
     " Your target is:\n{instruction}"
 )
 

--- a/models/duvo_eye_1.py
+++ b/models/duvo_eye_1.py
@@ -1,0 +1,137 @@
+"""
+Adapter for duvo-eye-1 (https://huggingface.co/duvoai/duvo-eye-1).
+
+duvo-eye-1 is Hcompany/Holo-3.1-35B-A3B fine-tuned with a LoRA adapter on
+duvoai/SynthUI for single-step GUI element grounding. The model emits
+{"x": int, "y": int} in [0, 1000] relative to the input image.
+
+This adapter queries an OpenAI-compatible endpoint. Serve the model with vLLM
+before running the evaluation (bf16 weights are ~66 GB: one H200 at TP=1, or
+2x80 GB at TP=2):
+
+  vllm serve duvoai/duvo-eye-1 \
+    --served-model-name duvo-eye-1 \
+    --tensor-parallel-size 2 \
+    --max-model-len 16384 \
+    --gpu-memory-utilization 0.90 \
+    --mm-processor-kwargs '{"max_pixels": 8000000}'
+
+Then:
+
+  python eval_screenspot_pro.py \
+    --model_type duvo_eye_1 \
+    --model_name_or_path duvo-eye-1 \
+    --screenspot_imgs /path/to/ScreenSpot-Pro/images \
+    --screenspot_test /path/to/ScreenSpot-Pro/annotations \
+    --task all --inst_style instruction --language en --gt_type positive \
+    --log_path results/duvo_eye_1.json
+
+Environment variables:
+  DUVO_EYE_1_ENDPOINT: OpenAI-compatible base URL (default http://127.0.0.1:8000/v1)
+"""
+import base64
+import json
+import os
+import re
+from io import BytesIO
+
+import openai
+from PIL import Image
+
+DEFAULT_ENDPOINT = "http://127.0.0.1:8000/v1"
+
+# Prompt contract from the duvo-eye-1 model card (inherited from the base
+# model's element-localization recipe). Used verbatim in training and eval.
+PROMPT_TEMPLATE = (
+    "Localize an element on the GUI image according to the provided target "
+    "and output a click position.\n"
+    ' * You must output a valid JSON following the format: '
+    '{"x": int 0-1000, "y": int 0-1000}\n'
+    " Your target is:\n{instruction}"
+)
+
+
+def convert_pil_image_to_base64(image):
+    buffered = BytesIO()
+    image.save(buffered, format="PNG")
+    return base64.b64encode(buffered.getvalue()).decode()
+
+
+class DuvoEye1Model:
+    def __init__(self):
+        self.client = openai.OpenAI(
+            api_key=os.environ.get("OPENAI_API_KEY", "EMPTY"),
+            base_url=os.environ.get("DUVO_EYE_1_ENDPOINT", DEFAULT_ENDPOINT),
+        )
+        self.model_name = "duvo-eye-1"
+        self.override_generation_config = {"temperature": 0.0}
+
+    def load_model(self, model_name_or_path="duvo-eye-1"):
+        # The model runs behind an OpenAI-compatible server (see module
+        # docstring); model_name_or_path is the served model name.
+        self.model_name = model_name_or_path
+
+    def set_generation_config(self, **kwargs):
+        self.override_generation_config.update(kwargs)
+
+    def _parse_point(self, response_text):
+        """Parse {"x": int, "y": int} in [0, 1000] from the response."""
+        try:
+            pred = json.loads(response_text)
+            return float(pred["x"]), float(pred["y"])
+        except (json.JSONDecodeError, KeyError, TypeError, ValueError):
+            pass
+        match = re.search(
+            r'"x"\s*:\s*(\d+(?:\.\d+)?)\s*,\s*"y"\s*:\s*(\d+(?:\.\d+)?)',
+            response_text,
+        )
+        if match:
+            return float(match.group(1)), float(match.group(2))
+        return None
+
+    def ground_only_positive(self, instruction, image):
+        if isinstance(image, str):
+            image_path = image
+            assert os.path.exists(image_path) and os.path.isfile(image_path), "Invalid input image path."
+            image = Image.open(image_path).convert("RGB")
+        assert isinstance(image, Image.Image), "Invalid input image."
+
+        base64_image = convert_pil_image_to_base64(image)
+
+        response = self.client.chat.completions.create(
+            model=self.model_name,
+            messages=[
+                {
+                    "role": "user",
+                    "content": [
+                        {
+                            "type": "image_url",
+                            "image_url": {
+                                "url": f"data:image/png;base64,{base64_image}",
+                            },
+                        },
+                        {
+                            "type": "text",
+                            "text": PROMPT_TEMPLATE.format(instruction=instruction),
+                        },
+                    ],
+                },
+            ],
+            temperature=self.override_generation_config["temperature"],
+            max_tokens=64,
+            extra_body={"chat_template_kwargs": {"enable_thinking": False}},
+        )
+        response_text = response.choices[0].message.content
+
+        point = self._parse_point(response_text)
+        if point is not None:
+            # [0, 1000] -> relative [0, 1]
+            point = [point[0] / 1000.0, point[1] / 1000.0]
+
+        return {
+            "result": "positive",
+            "format": "x1y1x2y2",
+            "raw_response": response_text,
+            "bbox": None,
+            "point": point,
+        }


### PR DESCRIPTION
## duvo-eye-1 — 72.9% on ScreenSpot-Pro (self-reported)

**Model:** [duvoai/duvo-eye-1](https://huggingface.co/duvoai/duvo-eye-1) (public weights)
**Authors:** Duvo

### Method

Holo-3.1-35B-A3B (3B active) with a LoRA adapter (rank 64, alpha 128, lr 7e-5, 1 epoch) trained on duvoai/SynthUI (14.9k synthetic enterprise-UI rows). No benchmark data in training. The model emits `{"x": int, "y": int}` in [0, 1000] relative to the input image; the point is scaled to absolute pixels via the original image dimensions.

### Results (full English split, all 1,581 samples)

| Category | Icon | Text | Avg |
|---|---|---|---|
| Office | 81.1 | 89.3 | 87.4 |
| Scientific | 54.5 | 82.6 | 70.5 |
| Dev | 67.6 | 84.4 | 76.3 |
| CAD | 45.3 | 71.6 | 65.1 |
| Creative | 49.0 | 79.3 | 66.6 |
| OS | 65.2 | 84.1 | 75.5 |
| **Overall** | **59.3** | **81.4** | **72.9** |

0.0% unparseable outputs (1,581/1,581 valid coordinate responses). For reference, H Company's published ScreenSpot-Pro number for the base Holo-3.1-35B-A3B is 71.5 (their model card).

### Protocol (honest notes)

- **Self-reported**, from our own harness (`bench_eval.py`, included in the predictions dataset), not this repo's `eval_screenspot_pro.py`. The adapter in this PR reproduces the protocol inside your harness.
- Single-shot, temperature 0, max_tokens 64, thinking disabled (`chat_template_kwargs: {"enable_thinking": false}`), guided JSON decoding.
- vLLM 0.22.1 with `mm-processor-kwargs {"max_pixels": 8000000}`.
- Exact-match scoring: predicted point inside ground-truth bbox; unparseable output = miss.
- Per-sample predictions (raw output, parsed point, absolute pixels, hit/miss) are published for independent rescoring: [duvoai/duvo-eye-1-evals](https://huggingface.co/datasets/duvoai/duvo-eye-1-evals) (`screenspot-pro/bench_sspro_highres_duvo-eye-1.predictions.jsonl`). The category table above was recomputed from those raw outputs joined against the dataset annotations.

### Files changed

- `models/duvo_eye_1.py` — adapter implementing `ground_only_positive()` (same interface as `models/holo1_5.py`), so results can be reproduced with this repo's harness.
- `model_factory.py` — added `duvo_eye_1` model type.

### Usage

```bash
python eval_screenspot_pro.py \
  --model_type duvo_eye_1 \
  --model_name_or_path duvoai/duvo-eye-1 \
  --screenspot_imgs /path/to/ScreenSpot-Pro/images \
  --screenspot_test /path/to/ScreenSpot-Pro/annotations \
  --task all --inst_style instruction --language en --gt_type positive \
  --log_path results/duvo_eye_1.json
```
